### PR TITLE
Update sonar-scanner script to be more reliable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ yarn-error.log*
 *.sln
 *.sw*
 
+
+**/*.jar
+.npmrc
+test-report.html
+.scannerwork/**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,12 +31,12 @@ pipeline {
             parallel {
                 stage('Dependency Check') {
                     steps {
+                        sh 'npm --registry http://nexus-labs-ci-cd.apps.domino.rht-labs.com/repository/npm-group/ install'
                         echo 'npm audit'
                     }
                 }
                 stage('Compile & Test') {
                     steps {
-                        sh 'npm install'
                         sh 'npm run test:unit'
                         sh 'npm run build'
                         publishHTML(target: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,12 +31,12 @@ pipeline {
             parallel {
                 stage('Dependency Check') {
                     steps {
-                        sh 'npm --registry http://nexus-labs-ci-cd.apps.domino.rht-labs.com/repository/npm-group/ install'
                         echo 'npm audit'
                     }
                 }
                 stage('Compile & Test') {
                     steps {
+                        sh 'npm --registry http://nexus-labs-ci-cd.apps.domino.rht-labs.com/repository/npm-group/ install'
                         sh 'npm run test:unit'
                         sh 'npm run build'
                         publishHTML(target: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,6 +36,9 @@ module.exports =
         "pageTitle": "Test Report"
       }]
     ],
+    testMatch: [
+      "**/*.steps.js"
+    ],
     moduleNameMapper: {
       'components/([^\\.]*).vue$': '<rootDir>/src/components/$1.vue',
       '^vue$': 'vue/dist/vue.common.js',
@@ -59,4 +62,5 @@ module.exports =
     snapshotSerializers: [
       '<rootDir>/node_modules/jest-serializer-vue'
     ]
+    
   }

--- a/sonar-scanner
+++ b/sonar-scanner
@@ -20,7 +20,7 @@
 ####
 set -o pipefail
 
-for cmd in {mvn,python,curl}; do
+for cmd in {./mvnw,python,curl}; do
   if ! command -v ${cmd} > /dev/null; then
   >&2 echo "This script requires '${cmd}' to be installed."
     exit 1

--- a/tests/unit/features/Login.feature
+++ b/tests/unit/features/Login.feature
@@ -1,0 +1,8 @@
+Feature: As a Human Review analyst
+I need to log in to Human Review page
+so that I can perform a review on STIX file
+
+Scenario: Login to the HR page 
+ Given I am at the Login page
+   When  - I enter username and password 
+    Then I should be able to see "Pending Messages" 

--- a/tests/unit/features/hr.feature
+++ b/tests/unit/features/hr.feature
@@ -1,0 +1,11 @@
+Feature: As a Human Review analyst 
+I need to be able to view the list of HR Pending fields graphical web interface 
+so that review items can be processed for eventual dissemination.
+
+Background:
+    Given I am successfully login to the HR page with the "username" and "password"
+
+Scenario: Select "Confirm Risk" action on HR page for a STIX package with one HR field
+    When I select "Confirm Risk" action on a single row package
+    Then the "Disseminate" button is enabled
+ 


### PR DESCRIPTION
The updated sonar-scanner script pulls the runtime from Maven so that it will always grab the latest in a way which is reliable and resilient.