### PR TITLE
DHS-58-enable-npm-audit-cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
             parallel {
                 stage('Dependency Check') {
                     steps {
+                        sh 'npm config set cache /tmp'
                         sh 'npm audit --json | npm-audit-html -o npm-audit-report.html'
                         publishHTML(target: [
                             reportDir             : './',


### PR DESCRIPTION
added config for caching location for npm audit